### PR TITLE
1.2.0 update

### DIFF
--- a/.github/workflows/build-on-dev-merge.yml
+++ b/.github/workflows/build-on-dev-merge.yml
@@ -1,13 +1,9 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
-
-
-name: Build on merge
+name: Build on dev PR opened
 
 on:
   pull_request:
     types: [ opened, reopened, synchronize ]
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build-on-pr:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,12 +1,11 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
-
 name: Push to NPM
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   push-to-npm:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 /lib
-/test-dolinks
+/dolinks-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 1.2.0
-  - DEPRECATED: passing text as v-dolinks directive arg is deprecated. Pass text to your tage inner text directly. Both is working for compability, but will be removed soon:
+  - DEPRECATED: passing text as v-dolinks directive arg is deprecated. Pass text to your tag inner text directly. Both are working for compatibility, but arg passing will be removed soon:
     - wrong: <p v-dolinks="'your text'"></p>
     - right: <p v-dolinks>{{ yourTextValue }}</p>
   - Changed links detecting method - increased parsing speed x10 ops/sec (measured by performance.now(), compared to 1.1.21);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 1.2.0
+  - DEPRECATED: passing text as v-dolinks directive arg is deprecated. Pass text to your tage inner text directly. Both is working for compability, but will be removed soon:
+    - wrong: <p v-dolinks="'your text'"></p>
+    - right: <p v-dolinks>{{ yourTextValue }}</p>
+  - Changed links detecting method - increased parsing speed x10 ops/sec (measured by performance.now(), compared to 1.1.21);
+  - Replaced RegExp (check README);
+  - Bug fixed: if there was an <a> tag in text, it was hard to predict what are you going to get as the result;
+  - Add code comments;
+  - Updated README.md to 1.2.0.
+
 ### 1.1.21
   - Updated README.md
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # dolinks
+> ### Not tested with Vue3
 > Vue directive to make links clickable in chosen HTML component, preserving newlines symbols of your text.
 
   - [Instalation](#installation)
-  - [How to use](#how-to-use)
+  - [Usage examples](#usage-examples)
+    - [Preserve your \n symbols](#preserve-your-n-symbols)
+    - [Sanitizes all other HTML tags](#sanitizes-all-other-html-tags)
   - [Options](#options)
   - [Changelog](https://github.com/vladhutsal/dolinks/blob/main/CHANGELOG.md)
 
 
 ## Installation
-```$ npm i dolinks```
+```
+$ npm i dolinks
+```
 
 ### Import
 ```javascript
@@ -32,19 +37,55 @@ Pass options object as a Vue.use() parameter:
 Vue.use(dolinks, options);
 ```
 
-## How to use
-Pass text which you want to linkify as ```v-dolinks``` directive argument:</br>
-> **Note that text inside of your tag (\<p> in current example) is ignored.**
+## Usage examples
+dolinks assumes that you'll pass your text to the template using the [Vue "Mustache" syntax](https://v2.vuejs.org/v2/guide/syntax.html#Text).
+  1. Mark you HTML tag with ```v-dolinks``` directive:</br>
+  2. Pass text using ```{{ yourText }}```
+
+### Preserve your \n symbols:
 #### Input:
-```html
-<p v-dolinks="'Some text description in <p>inside_text</p> tag and some https://achievki.io link'">My tag text</p>
+```javascript
+<template>
+  <p v-dolinks :style="{'white-space': 'pre-wrap'}">
+    {{ yourText }}
+  </p>
+</template>
+
+<script>
+  data() {
+    return {
+      yourText: 'Some \n splited \n https://achievki.io \n here'
+    }
+  }
+</script>
 ```
 #### Output: 
 ```html
-<p>
-  Some text description in <p>inside_text</p> tag and some
-  <a href="https://achievki.io" target="_blank">https://achievki.io</a>
- link
+<p style="white-space: pre-wrap;">
+  "Some splited"
+  <a href="https://achievki.io" target="_blank">https://achievki.io</a> 
+ " here"
+</p>
+```
+
+### Sanitizes all other HTML tags:
+#### Input:
+```javascript
+<script>
+  data() {
+    return {
+      yourText: 'https://example.com Let`s try to pass some <script> with <a href="https://google.com">GOOGLE LINK</a> <\/script>'
+    }
+  }
+</script>
+```
+#### Output: 
+```html
+<p style="white-space: pre-wrap;">
+  <a href="https://example.com" target="_blank">https://example.com</a>
+  " Let`s try to pass some &lt;script&gt; with &lt;a href=""
+  <a href="https://google.com" target="_blank">https://google.com</a>
+  ""&gt;GOOGLE LINK&lt;/a&gt; &lt;/script&gt;
 </p>
 ```
 
@@ -55,7 +96,7 @@ Text, matched this regex, also will be used as a value for **href** atribute.
 
 **Default:**
 ```javascript
-/^(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})$/
+/https?:\/\/[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b[-a-zA-Z0-9@:%._\+~#=\/]{0,2048}/
 ```
 
 ### target

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dolinks",
-  "version": "1.1.21",
+  "version": "1.2.0",
   "description": "Make links clickable in chosen HTML component preserving newlines symbols of your text",
   "main": "lib/install.js",
   "types": "lib/install.d.ts",

--- a/src/dolinks.ts
+++ b/src/dolinks.ts
@@ -1,47 +1,53 @@
 import { VNode } from 'vue';
 import { DirectiveBinding } from 'vue/types/options';
 
-import { IOptions } from './helpers';
-import { validHTMLtagRegExp } from './helpers';
-import { sanitizeHTMLTags, updateLinkedPhrase, defineOptions, handleConsoleWarnings} from './helpers';
+import { IOptions, ITextExists, IUserOptions } from './intrefaces';
+import { compileLinkTag, getInnerText, getTextExistence } from './helpers';
+import { sanitizeHTMLTags, defineOptions, handleWarningsAndErrors} from './helpers';
 
 
-function updateHTMLWithLinks(el: HTMLElement, bind: DirectiveBinding, vnode: VNode, options: IOptions = {}) {
-  const { urlRegEx, target, disableWarnings } = defineOptions(options);
-  const attrText = bind.value ? bind.value : undefined;
+function updateHTMLWithLinks(
+  el: HTMLElement, bind: DirectiveBinding, vnode: VNode, userOptions: IUserOptions = {}
+) {
+  const argText = bind.value ? bind.value : '';
 
-  const error = handleConsoleWarnings(vnode, attrText, disableWarnings);
-  if (error) {
-    return;
-  }
+  const options: IOptions = defineOptions(userOptions);
+  const textExists: ITextExists = getTextExistence(el.innerHTML, argText);
 
-  const spaceSplitedText = attrText!.split(' ');
-  const linkedTextArr = spaceSplitedText.map((word: string) => {
-    const nSplitedPhrase = word.split(/\n/);
-    let nEnd = nSplitedPhrase.length > 1 ? nSplitedPhrase.length : 0;
-    
-    let nSplitedPhraseLinked = '';
-    for (let nSplitedTerm of nSplitedPhrase) {
-      nEnd -= 1;
+  handleWarningsAndErrors(vnode, options, textExists);
+  const innerText = getInnerText(textExists, el.innerHTML, argText);
 
-      const isTermLink = nSplitedTerm.match(urlRegEx);
-      const isTermHTMLTag = nSplitedTerm.match(validHTMLtagRegExp);
-      
-      if (isTermHTMLTag) {
-        nSplitedTerm = sanitizeHTMLTags(nSplitedTerm);
-      }
+  const innerSanitizedText = sanitizeHTMLTags(innerText);
+  const validLinks = innerSanitizedText.match(options.urlRegEx);
 
-      if (isTermLink) {
-        const linkEl = `<a href="${nSplitedTerm}" target="${target}">${nSplitedTerm}</a>`;
-        nSplitedPhraseLinked = updateLinkedPhrase(nEnd, nSplitedPhraseLinked, linkEl);
-        continue;
-      }
-      nSplitedPhraseLinked = updateLinkedPhrase(nEnd, nSplitedPhraseLinked, nSplitedTerm);
+  // First symbol of current textPartWithLink
+  let startIdx = 0;
+
+  // Last symbol of the link index
+  let endIdx = 0;
+
+  // Walk through text link by link, replacing each matched link
+  // with <a href="" target=""> tag and adding all textPartWithLink to resultText
+  let resultText = '';
+  if (validLinks) {
+    for (const validLink of validLinks) {
+      const linkTag = compileLinkTag(validLink, options.target);
+
+      endIdx = innerSanitizedText.indexOf(validLink, startIdx) + validLink.length;
+      const textPartWithLink = innerSanitizedText.substring(startIdx, endIdx);
+      const textWithLinkTag = textPartWithLink.replace(validLink, linkTag);
+
+      resultText += textWithLinkTag;
+      startIdx = endIdx;
     }
-    return nSplitedPhraseLinked;
-    
-  });
-  el.innerHTML = linkedTextArr.join(' ');
+    // Append text if left after linking:
+    const resTextLengthDiff = endIdx < innerSanitizedText.length;
+    if (resTextLengthDiff) {
+      const ending = innerSanitizedText.slice(endIdx);
+      resultText += ending;
+    }
+  }
+  el.innerHTML = resultText.length > 0 ? resultText : innerSanitizedText;
 }
 
 export default updateHTMLWithLinks;

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,8 @@
+export const defaultWarnings = false;
+export const defaultTarget = '_blank';
+
+export const defaultUrlRegExp = new RegExp([
+  'https?:\/\/[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.',
+  '[a-zA-Z0-9()]{1,6}\\b[-a-zA-Z0-9@:%._\\+~#=\\/]{0,2048}',
+  ].join(''), 'g'
+);

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,9 +1,9 @@
 import _Vue from 'vue';
 import updateHTMLWithLinks from './dolinks';
-import { IOptions } from './helpers';
+import { IUserOptions } from './intrefaces';
 
 const dolinks = {
-  install(Vue: typeof _Vue, options: IOptions) {
+  install(Vue: typeof _Vue, options: IUserOptions) {
     Vue.directive("dolinks", {
       inserted: (el, bind, vnode) => updateHTMLWithLinks(el, bind, vnode, options),
       componentUpdated: (el, bind, vnode) => updateHTMLWithLinks(el, bind, vnode, options),

--- a/src/intrefaces.ts
+++ b/src/intrefaces.ts
@@ -1,0 +1,19 @@
+export type TTarget = '_self' | '_blank' | '_parent' | '_top';
+
+export interface ITextExists {
+  [key: string]: boolean;
+  inner: boolean;
+  arg: boolean;
+}
+
+export interface IUserOptions {
+  urlRegEx?: RegExp;
+  target?: TTarget;
+  disableWarnings?: boolean;
+};
+
+export interface IOptions {
+  urlRegEx: RegExp;
+  target: TTarget;
+  disableWarnings: boolean;
+}


### PR DESCRIPTION
 - **DEPRECATED**: passing text as v-dolinks directive arg is deprecated. Pass text to your tag inner text directly. Both are working for compatibility, but will be removed soon:
    - wrong: ```<p v-dolinks="'your text'"></p>```
    - right: `<p v-dolinks>{{ yourTextValue }}</p>`
  - Changed links detecting method - increased parsing speed x10 ops/sec (measured by performance.now(), compared to 1.1.21);
  - Replaced RegExp (check README);
  - Bug fixed: if there was a <a> tag in text, it was hard to predict what are you going to get as the result;
  - Add code comments;
  - Updated README.md to 1.2.0.